### PR TITLE
fix precision matrix initialization

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -46,9 +46,10 @@ class SkipGramSmoothing:
                             + self.vals[i] ** (-1)
                         )
                     self.precision[i][j] = v
-                if (i == 0 and j > 0) or (i > 0 and j == 0):
-                    v = -self.vals[max(i, j) - 1] ** (-1)
+                if i + 1 == j:
+                    v = -self.vals[i] ** (-1)
                     self.precision[i][j] = v
+                    self.precision[j][i] = v
         logging.debug(f" [init] dwe.precision: \n{self.precision}")
         # precision = B^T@B, B: bidiagonal matrix
         # v, w: variational parameters


### PR DESCRIPTION
a precision matrix should be a trigonal matrix because a result of Cholesky decomposition is restricted to be bidiagonal.

- paper:

![スクリーンショット 2021-12-02 17 21 32](https://user-images.githubusercontent.com/45454055/144384328-7a6b442b-340d-4950-bba8-0c31c33bdc2f.png)

- fixed:
![スクリーンショット 2021-12-02 17 22 23](https://user-images.githubusercontent.com/45454055/144384467-6550359b-0d53-4728-b71f-1c53a3aaa38a.png)

